### PR TITLE
Fix Build Error on Linux

### DIFF
--- a/Sources/TinyNetworking/Endpoint.swift
+++ b/Sources/TinyNetworking/Endpoint.swift
@@ -282,7 +282,7 @@ extension URLSession {
 }
 #endif
 
-#if swift(>=5.5)
+#if swift(>=5.5) && canImport(Darwin)
 @available(iOS 15, macOS 12.0, watchOS 8, tvOS 15, *)
 public extension URLSession {
     /// Loads the contents of a `Endpoint` and delivers the data asynchronously.


### PR DESCRIPTION
Building on Linux fails due to use of `URLSession.data(for:delegate:)` in the async version of `URLSesssion.load(_:)`. This puts the extension containing that method behind a `canImport(Darwin)` directive to fix that.